### PR TITLE
ignore case during span context extraction from http headers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    haystack_agent:
-    image: expediadotcom/haystack-agent:0.1
+    image: expediadotcom/haystack-agent:0.1.3
     depends_on:
     - zookeeper
     - kafkasvc

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -91,9 +91,11 @@ func (suite *TracerTestSuite) TestTracerWithDualSpanMode_1() {
 	serverTag := opentracing.Tag{Key: "span.kind", Value: "server"}
 	clientTag := opentracing.Tag{Key: "span.kind", Value: "client"}
 	carrier := map[string]string{
-		"Trace-ID":  "T1",
-		"Span-ID":   "S1",
-		"Parent-ID": "P1",
+		"trace-id":        "T1",
+		"Span-ID":         "S1",
+		"Parent-ID":       "P1",
+		"Baggage-myKey":   "myVal",
+		"baggage-mykey-1": "myval",
 	}
 	upstreamSpanContext, _ := suite.dualSpanModeTracer.Extract(opentracing.HTTPHeaders, carrier)
 	serverSpan := suite.dualSpanModeTracer.StartSpan("op1", serverTag, opentracing.ChildOf(upstreamSpanContext))
@@ -110,6 +112,8 @@ func (suite *TracerTestSuite) TestTracerWithDualSpanMode_1() {
 	receivedServerSpan := dispatcher.spans[1]
 	receivedServerSpanCtx := receivedServerSpan.Context().(*SpanContext)
 	suite.Equal(receivedServerSpanCtx.TraceID, "T1", "Trace Ids should match")
+	suite.Equal(receivedServerSpanCtx.Baggage["myKey"], "myVal", "baggage key should match")
+	suite.Equal(receivedServerSpanCtx.Baggage["mykey-1"], "myval", "baggage lowercase key should match")
 	suite.NotEqual(receivedServerSpanCtx.SpanID, "S1", "SpanId should be newly created")
 	suite.NotEqual(receivedServerSpanCtx.SpanID, "P1", "SpanId should be newly created")
 	suite.NotEqual(receivedServerSpanCtx.SpanID, "T1", "SpanId should be newly created")


### PR DESCRIPTION
HTTP RFC : https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

```
HTTP header fields, which include general-header (section 4.5), request-header (section 5.3), 
response-header (section 6.2), and entity-header (section 7.1) fields, follow the same generic format 
as that given in Section 3.1 of RFC 822 [9]. Each header field consists of a name followed by a colon
(":") and the field value. *Field names are case-insensitive.*
```

When SpanContext is extracted using `TextMapPropagator`, keys in the carrier can be of different case. In many cases, carrier is `HttpHeadersCarrier` which exposes HTTP headers read from transport. According to RFC, these header names are case insensitive.  Some of the servers and clients do not maintain case of the header provided/read. 